### PR TITLE
友链：xf_blog

### DIFF
--- a/src/data/friends/xf_blog.json
+++ b/src/data/friends/xf_blog.json
@@ -5,3 +5,4 @@
 	"url": "https://xfcnl.github.io",
 	"backlink": "https://xfcnl.github.io/link/"
 }
+

--- a/src/data/friends/xf_blog.json
+++ b/src/data/friends/xf_blog.json
@@ -1,7 +1,7 @@
 {
 	"name": "xf_blog",
-	"avatar": "https://github.com/lm-xiao-fen/lm-xiao-fen.github.io/blob/main/image/MEITU_20260128_220225596.jpg?raw=true",
+	"avatar": "https://github.com/xfcnl/xfcnl.github.io/blob/main/image/MEITU_20260128_220225596.jpg?raw=true",
 	"description": "立志用 cloudflare workers，GitHub pages 和 vercel 做出整个互联网的up（虽然不会成功",
-	"url": "https://lm-xiao-fen.github.io/",
-	"backlink": "https://lm-xiao-fen.github.io/feed-link/"
+	"url": "https://xfcnl.github.io",
+	"backlink": "https://xfcnl.github.io/link/"
 }


### PR DESCRIPTION
我在贵站已有友链，现因部分原因，原来的链接已被弃用，仅作为重定向到新的网站使用。现需将贵站的旧友链链接更新为新链接